### PR TITLE
Add FY26 proposal scoring rubric document

### DIFF
--- a/docs/fy26-suits-proposal-rubric.md
+++ b/docs/fy26-suits-proposal-rubric.md
@@ -1,0 +1,91 @@
+# FY26 NASA SUITS Proposal Scoring Rubric Requirements
+
+This document distills the scoring rubric from the FY26 NASA SUITS Proposal Guidelines. Use it as a checklist to verify proposal readiness before submission.
+
+## Technical Section (Total 80 points)
+
+### Design Description (25 points)
+- **Key requirements**
+  - State the design concept goals and expected results clearly.
+  - Provide a roadmap for integrating AI to deliver autonomous functions.
+  - Address user interfaces for the spacesuit and pressurized rover, navigation, and the autonomy/interoperability requirements.
+- **Scoring bands**
+  - **0–6 points**: Design goals or expected results are unclear. Little to no evidence of innovative UI or interaction methods. Meets at most one challenge component.
+  - **7–13 points**: Goals/results are vague. Minimal evidence of innovative UI or interaction methods. Meets at least two challenge components.
+  - **14–19 points**: Goals/results generally described. Some evidence of innovation in UI or interaction methods. Meets at least three challenge components.
+  - **20–25 points**: Goals/results are clearly and concisely written with substantial evidence (e.g., visuals) of innovative UI or interaction methods. Meets most or all challenge components.
+
+### Concept of Operations (10 points)
+- **Key requirements**
+  - Describe the user interfaces, autonomy, and interoperability from an operational perspective for both the pressurized rover and spacesuit.
+- **Scoring bands**
+  - **0–2 points**: Operational description is unclear or insufficient.
+  - **3–5 points**: Few details; difficult to comprehend operationally.
+  - **6–8 points**: General details provide only a minimal or basic operational understanding.
+  - **9–10 points**: Clear, concise, and fully detailed operational explanation.
+
+### Feasibility (10 points)
+- **Key requirements**
+  - Demonstrate the concept’s viability as a solution to the technical need.
+  - Explain how the concept will be produced.
+- **Scoring bands**
+  - **0–1 point**: Concept lacks viability, fails to meet need, and offers no production evidence.
+  - **2–4 points**: Low viability with insignificant contributions to the need; little production evidence.
+  - **5–7 points**: Sufficient viability with some contributions; minimal production evidence.
+  - **8–10 points**: High viability with significant contributions; ample, detailed production evidence.
+
+### Artificial Intelligence Integration (15 points)
+- **Key requirements**
+  - Explain how and where AI will be integrated.
+  - Identify which LLMs or other AI models will be used and justify the selections.
+  - Provide plans to mitigate hallucinations or other mission-endangering behaviors.
+- **Scoring bands**
+  - **0–3 points**: Lacks explanation of AI integration, model choices, or mitigation; shows little understanding.
+  - **4–7 points**: Basic, vague, or impractical integration plan; minimal model justification; rudimentary mitigation strategy.
+  - **8–11 points**: Practical integration with some detail; reasonable model justification; practical but not innovative mitigation plan.
+  - **12–15 points**: Comprehensive integration plan; well-justified model choices; thorough and effective mitigation strategy.
+
+### Effectiveness of the Proposed Project Schedule (5 points)
+- **Key requirements**
+  - Present a comprehensive schedule detailing objectives, task timelines, labor distribution, and resource use.
+- **Scoring bands**
+  - **0 points**: Lacks effective planning; offers little to no path to meet objectives.
+  - **1–2 points**: Few details; only vague description of meeting objectives.
+  - **3–4 points**: Minimal details; barely describes how tasks and objectives will be met.
+  - **5 points**: Highly detailed, comprehensive plan demonstrating how objectives and tasks will be met effectively.
+
+### Human-in-the-Loop (HITL) Testing (10 points)
+- **Key requirements**
+  - Provide a HITL test plan covering: schedule of events, protocols, metrics/measures, subject pools/demographics, evaluation method for challenge requirements, and safety considerations.
+- **Scoring bands**
+  - **1–2 points**: No plan or components are insufficient, unsafe, or unclear.
+  - **3–5 points**: Includes few required components needed for effective, safe HITL testing.
+  - **6–7 points**: Includes most components but lacks full detail.
+  - **8–10 points**: Clearly and concisely addresses every required component for effective, safe HITL testing.
+
+### Technical References (5 points)
+- **Key requirements**
+  - Cite relevant works within the text and provide a properly formatted bibliography.
+- **Scoring bands**
+  - **0 points**: No references.
+  - **1–2 points**: Single reference cited; formatting incorrect.
+  - **3–4 points**: At least one correctly formatted reference.
+  - **5 points**: Two or more correctly formatted references.
+
+## Community and Industry Engagement Section (Total 20 points)
+- **Key requirements**
+  - Plan a diverse mix of outreach activities and industry engagements, totaling at least four events for full credit.
+  - Detail projected audience types, participant counts, engaged community leaders, and implementation plans.
+  - List potential industry partners, alignment with project goals, and the team’s professional development strategy (mentorship, skills, certifications, career opportunities, or awareness-building).
+- **Scoring bands**
+  - **1–5 points**: Only one event planned **or** no detail on implementation, audience, participants, or industry alignment.
+  - **6–10 points**: Minimum of two events with minimal detail on implementation, audience, participants, or industry alignment.
+  - **11–15 points**: Minimum of three events with sufficiently detailed implementation plan **and/or** detailed list of aligned industry partners.
+  - **16–20 points**: Minimum of four events with highly descriptive and relevant implementation plan **and/or** highly detailed list of aligned industry partners.
+
+## Administrative Requirements (Non-scored but mandatory)
+- Institutional letter of endorsement signed by appropriate leadership, or proposal is rejected.
+- Statement of supervising faculty on institutional letterhead, including commitment to oversee all stages and acknowledging consequences for non-compliance.
+- Optional Statement of Rights of Use granting NASA usage rights; inclusion yields greater consideration. Must be signed by all team members and faculty advisors.
+
+Use this rubric document as a validation tool to ensure every requirement receives the attention needed for maximum scoring potential.


### PR DESCRIPTION
## Summary
- add a standalone markdown rubric that distills the FY26 NASA SUITS proposal scoring criteria
- capture scoring bands for every technical, engagement, and administrative requirement drawn from the official guidelines
- structure the document as a checklist to guide future proposal drafting and reviews

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee628dccbc832f8bfc2f6b9b198348