### PR TITLE
Add Markdown versions of FY26 SUITS PDFs

### DIFF
--- a/docs/fy26-suits-faqs.md
+++ b/docs/fy26-suits-faqs.md
@@ -1,0 +1,43 @@
+# NASA SUITS FY26 — Frequently Asked Questions
+
+## General
+1. **What should be included in the Concept of Operations (CONOPS) section?**
+   - The CONOPS section should specify how your design addresses each challenge requirement by detailing how the design evaluator will interface with your device during every procedural step outlined in the mission description.
+   - Be explicit about how telemetry and other information are displayed and how the AI Assistant is implemented throughout the experience.
+2. **Can we attach videos to our proposal via YouTube links?**
+   - Assume reviewers will not watch proposal videos. You may include a video as an additional communication aid, but keep any video short.
+3. **Are international students able to participate in this challenge?**
+   - International students can participate and contribute at their institution, but they cannot be badged to enter NASA's Johnson Space Center (JSC) in Houston where the test week will occur.
+4. **Is there a team size limit?**
+   - There is no formal limit, though most teams include 8–15 people.
+   - Each team member should contribute within a defined role. Teams are limited to eight badged participants during onsite test week (seven students and one faculty member).
+   - Large teams are encouraged to split into separate groups and submit unique proposals.
+5. **Do you want system architecture flowcharts in UML 2.0, SysML, etc.?**
+   - Use whichever modeling approach your team feels best conveys the architecture.
+6. **Can students under the age of 18 participate?**
+   - No. All participants must be at least 18 to sign the Statement of Rights and attend test week.
+7. **If we previously submitted a NASA SUITS proposal, can we extend it or should we start from scratch?**
+   - You may reuse aspects of previous designs if they carry over to this year's challenges, but ensure you address this year's specific requirements first. NASA is looking for unique ideas.
+8. **Are international students allowed to be team leads?**
+   - STEM Gateway limits team leads to U.S. citizens. You may appoint co-leads so long as at least one is a U.S. citizen.
+   - Only U.S. citizens and Legal Permanent Residents (LPRs) will be badged to participate in the onsite culminating event.
+9. **Does our faculty advisor have to be an active faculty member from our institution?**
+   - Yes. The faculty advisor acts on behalf of the university and must hold a position recognized by the institution. Teams may consult additional faculty members as needed.
+
+## Technical and Devices
+10. **Can our team use whatever devices we want?**
+    - NASA SUITS strives to be device agnostic. If a head-mounted display (HMD) is used in the field during the EVA, it must be a passthrough AR device so crew members can safely see the ground while walking.
+11. **What language is the Telemetry Stream Server (TSS) written in?**
+    - The TSS is primarily implemented in JavaScript and TypeScript.
+12. **How do you receive data from the TSS?**
+    - All TSS data is sent via the WebSocket protocol (`ws`) and uses JSON/GeoJSON payloads.
+    - During testing you will point the TSS to the IP address of the device hosting the server.
+    - During test week NASA deploys the TSS on a local SUITSNET network at the test site. Teams must update their devices with NASA's host server IP address.
+13. **Can phones be used as peripheral devices?**
+    - Teams must list every peripheral device included in their design and identify any support they require from NASA SUITS (internet access, extra setup time, etc.) during the spring design review.
+    - NASA will either grant approval or follow up for more information before allowing external devices onsite.
+14. **Can we design our own custom hardware interface?**
+    - Yes. Include a mock-up of the custom interface and explain how it connects to the AR device in the proposal.
+    - If selected, teams must present all external devices at the spring design review before the NASA SUITS team will authorize bringing them onsite.
+15. **When will the telemetry stream become available?**
+    - NASA SUITS aims to provide the telemetry stream to selected teams between mid-December 2025 and early January 2026.

--- a/docs/fy26-suits-mission-description.md
+++ b/docs/fy26-suits-mission-description.md
@@ -1,0 +1,171 @@
+# NASA SUITS FY26 — Mission Description (2025–2026)
+
+## 1. Background
+NASA SUITS (Spacesuit User Interface Technologies for Students) is a software design challenge that engages college students across the United States in solving future spaceflight needs. The Artemis campaign is returning humans to the Moon for scientific discovery, economic benefits, and to inspire the Artemis Generation. That effort demands new approaches to extravehicular activity (EVA).
+
+NASA SUITS is a collaboration between the Extravehicular Activity and Human Surface Mobility Program (EHP) and NASA's Office of STEM Engagement. Entering its ninth year, the challenge connects students to authentic engineering problems involving displays, voice assistants, AI integration, and interoperability between spacesuits and rovers. Teams submit a proposal that covers both the spacesuit and pressurized rover (PR) systems, displays, and voice assistants. Selected teams are assigned to focus on either the PR or spacesuit asset and are paired with another team covering the complementary asset.
+
+Head-mounted displays used in spacesuit concepts must be passthrough AR devices. The pressurized rover operates in NASA's Digital Lunar Exploration Sites Unreal Simulation Tool (DUST). After the proposal phase, top teams develop their UI and supporting software, receive mentorship from NASA experts, and test their work in a mock EVA at NASA Johnson Space Center (JSC) in Houston in May 2026.
+
+## 2. Mission Concept
+NASA SUITS is creating a lunar EVA scenario for 2026. Each team is responsible for its UI, voice assistant, display hardware, and supporting software. Testing occurs at night in the JSC Rock Yard. Teams must account for lighting conditions on a pulverized granite surface with scoria boulders up to 1 m and craters up to 2 m deep and 20 m in diameter.
+
+Teams will be assigned to either the PR or spacesuit components and paired with another team for interoperability. Each team connects to a telemetry stream specific to its asset.
+
+### 2a. Pressurized Rover
+The PR team develops a display and control system for a rover operating in the DUST environment. Autonomous systems should navigate between locations, execute search-and-rescue patterns, perform path planning and object detection, and account for resource utilization. Integrating AI to accomplish these objectives is essential for a strong proposal.
+
+### 2b. Spacesuit
+The spacesuit team deploys its solution for one EVA crew member (EV). The interface can run on a head-mounted display, tablet, phone, or other device. The EV relies on both displays and a voice assistant to accomplish mission goals.
+
+### 2c. Artificial Intelligence Assistant (AIA)
+NASA SUITS aims to act as a force multiplier for astronauts by increasing efficiency and reducing cognitive load so crew members can focus on tasks best suited for humans. AI is central to this goal. Voice responses should use natural, concise language (e.g., “Primary O2 47%, Secondary 99%,” rather than verbose phrasing). AI also supports route planning for both PR and EV, accounting for consumable limits and adjusting as conditions change. Teams must implement guardrails that prevent hallucinations from jeopardizing mission-critical functions.
+
+### 2d. Mission Tasks
+#### Initial Scene
+An autonomous Lunar Terrain Vehicle (LTV) performs standard operations at a known location. An unknown error halts communications. The LTV’s last location and consumables are known. A software glitch likely kept the LTV operating autonomously until it entered automatic sleep mode due to low power. Teams must establish a search radius, map and execute a search pattern to locate the LTV, and guide the crew into range to egress and make repairs safely.
+
+#### Pressurized Rover Navigation
+The PR team demonstrates its UI and crew-autonomy system while navigating from the starting point to search for the lost LTV. Using the LTV’s last known position and consumables, the team establishes a search radius and pattern based on industry standards, adapting to terrain as it locates the LTV safely and efficiently. The pattern should adjust as new inputs (e.g., LiDAR, beacon signals) become available. The PR operates within the DUST environment.
+
+Evaluated PR features include autonomous best-path planning, hazard avoidance, consumable/resource tracking, and estimates of remaining resources relative to planned routes. Teams should estimate turnaround points where the rover must return to base to avoid depleting limited resources. When provided with a point of interest, predictive modeling should enable decision support that optimizes resource usage and reduces cognitive load. The PR broadcasts a simulated “wake-up call” that triggers the LTV when within range, shrinking the search area to under 500 m. Optional “warmer/colder” guidance may aid tracking within roughly 50 m.
+
+Upon arrival, the crew prepares for egress. The Umbilical Interface Assembly (UIA) is incorporated into the PR hatch.
+
+#### Egress
+Egress begins when the EV exits the airlock to start the EVA. Multiple steps must confirm the crew member can safely egress. The priority is showcasing intuitive displays and voice interactions as the EV performs the UIA procedures that prepare and check the portable life support system.
+
+The EV manipulates UIA switches per provided procedures. Appendix A includes a sample procedure, which may change before Test Week. After completing the egress task, the EV proceeds to navigation. Teams choose how to communicate the procedures (text checklists, computer vision, voice commands, combinations, or other approaches) and should integrate AI. Switch states from the UIA are provided through the Telemetry Stream Server (TSS).
+
+#### EV Navigation
+The navigation objective is to traverse safely and efficiently. Teams implement software that detects environmental hazards under lunar south pole lighting conditions and updates the EV as situations change. A sample lighting animation is available online. The system provides real-time alerts and recommends immediate actions such as alternate routes.
+
+Navigation solutions must remain effective yet non-obtrusive, allowing flexibility because destinations can change. Interfaces must include a 2D minimap for navigation assistance and may add a 3D map, computer-vision destination waypoints, or path indicators. Throughout the EVA, the LTV may send status updates that influence navigation.
+
+#### LTV Repair
+1. **Exit Recovery Mode (ERM)**
+   - Retrieve ERM procedures from the AI assistant.
+   - Follow the procedures and wait for confirmation that ERM succeeded before proceeding.
+2. **System Diagnosis**
+   - Command the AIA to conduct a system diagnosis when ready, while the EV performs visual inspections.
+   - Wait for diagnostics to complete; the AIA provides next steps and guides the EV through corrective procedures.
+3. **System Restart (Navigation Correction)**
+   - The AIA delivers and guides the EV through a physical restart of the rover navigation system.
+   - The AIA reports when the restart is complete and verifies position data.
+4. **Physical Repair Tasks**
+   - The AIA guides the EV through instrument repairs, which may include:
+     - Reconnecting a loose bus connector (must be repaired because power systems are limited).
+     - Replacing a damaged dust sensor (can be deferred if time is short; the AIA should recommend delaying when necessary).
+5. **Final Checks and Verification**
+   - The AIA conducts a final system diagnosis to confirm the rover is stable and recovery succeeded.
+
+#### Ingress
+EVA ends only when the EV safely returns inside the PR. After finishing EVA tasks, the EV follows navigation cues to the PR, using the UI’s breadcrumbs feature to retrace the path. The design should provide the shortest safe return route. Once docked, the EV completes final UIA procedures.
+
+## 3. NASA-Provided Systems and Equipment
+### 3a. Telemetry Stream Server (TSS)
+NASA supplies a TSS that simulates telemetry for lunar assets. A Unity/Unreal plugin helps integrate the TSS with team devices. Designs must retrieve and display the following telemetry at any time:
+
+- Pressurized Rover telemetry
+- LTV telemetry at 500 m
+- LTV telemetry at 50 m
+- UIA state data
+- Spacesuit telemetry
+- Display and Control Unit (DCU) status
+- LTV task board data
+
+### 3b. Umbilical Interface Assembly (UIA)
+The UIA contains multiple switches that teams manipulate to match desired egress configurations. Switch states feed into the TSS as booleans, giving real-time feedback. Teams are encouraged to employ creative methods (computer vision, voice assistants, etc.) to convey procedures and relevant telemetry while completing the checklist.
+
+### 3c. Lunar Terrain Vehicle (LTV)
+NASA provides the LTV and supporting framework to traverse the test-site terrain. Teams must receive and display LTV telemetry. The LTV features a task board with physical tasks (details released after team selection).
+
+### 3d. Display and Control Unit (DCU)
+The DCU includes switches that let the EV interact with suit systems. Switch states feed into the TSS, providing real-time feedback. The provided DCU lacks an integrated display; the spacesuit UI must present DCU information via the TSS. Systems controlled by the DCU include:
+
+- Battery (Local/UMB)
+- Oxygen (Primary/Secondary)
+- Communications (A/B)
+- Fan (Primary/Secondary)
+- Pump (Open/Close)
+- CO₂ (A/B)
+
+NASA will supply a method to simulate the DCU location system to support development.
+
+## 4. Requirements
+Requirements may evolve after team selection. Terminology:
+
+- **Shall** — required for a minimally viable product
+- **Should** — requested features with secondary priority
+- **May** — stretch goals for development
+
+### 4a. Pressurized Rover Requirements
+1. **Pressurized Rover Control**
+   - Shall develop a system for controlling the rover in the virtual DUST environment.
+2. **Spacesuit Telemetry**
+   - The UI may display crew biomedical data and shall display spacesuit system state data; all telemetry must be easily accessible.
+3. **LTV Telemetry**
+   - The UI shall display LTV beacon data and make it readily accessible.
+4. **Task Procedures**
+   - The UI shall display procedures for mission tasks, with easy access to all steps.
+5. **Map**
+   - The PR UI shall include a live 2D map tracking surface assets.
+   - The map may track crew locations, draw projected and traversed EV paths, display the LTV travel radius, track and adjust search patterns as new information arrives, and display/drop/share labeled points of interest (POIs) with the EV.
+   - The UI shall feature a caution and warning (C&W) system that alerts when telemetry is off-nominal and prompts the AIA to recommend procedures.
+   - Mission timers (HH:MM:SS) shall be displayed and adhere to standards provided to selected teams.
+6. **Autonomous Navigation System**
+   - Shall determine best paths, detect and avoid obstacles, accept updated destinations from the TSS, provide a map of lunar assets, and track rover speed, angle, and heading.
+7. **Autonomous Resource Utilization**
+   - Shall track life support systems and health, monitor rover resource usage (such as power) with predictive analytics, deliver real-time updates via the C&W system, and use the AIA to provide natural-language status updates with specific values.
+
+### 4b. Spacesuit Display Requirements
+1. **EV Telemetry** — The UI shall display EV suit and simulated biomedical data.
+2. **Map** — The UI shall display a 2D map, show planned search locations and routes to locate the LTV efficiently, display live asset locations (including other crew), and may include a 3D map.
+3. **Procedure List** — The UI shall display correct procedures for each EVA station and provide natural-language voice assistance.
+4. **Navigation** — The UI shall implement breadcrumbs for backtracking to the PR, should provide best-path navigation and navigation aids to POIs, and shall offer predictive maximum range estimates based on life-support usage and limits.
+5. **Drop Pins** — The design shall enable users to drop pins on the map at any time during the EVA.
+6. **Caution and Warning** — The UI shall feature a C&W system that alerts when suit or biometric telemetry becomes off-nominal and uses AI to recommend actions.
+
+### 4c. Peripheral Requirements
+These requirements apply to peripheral devices:
+1. Any external or additional device must be presented at the Software Design Review (SDR) and approved by NASA SUITS.
+2. Devices should communicate with team systems outside the TSS (e.g., Bluetooth).
+3. Devices must not include holes or openings that could trap fingers.
+4. Devices must not have sharp edges.
+5. Pinch points should be minimized and labeled.
+6. Electrical designs must meet additional requirements provided by NASA.
+
+## Appendix A: Sample UIA Procedures (EVA Egress)
+> **Note:** Procedures are subject to change before Test Week.
+
+### Connect UIA to DCU and Start Depress
+1. EV1 verifies umbilical connection from UIA to DCU.
+2. UIA: EMU PWR — ON.
+3. DCU: BATT — UMB.
+4. UIA: DEPRESS PUMP PWR — ON.
+
+### Prep O₂ Tanks
+1. UIA: OXYGEN O₂ VENT — OPEN.
+2. HMD: Wait until both Primary and Secondary O₂ tanks are &lt; 10 psi.
+3. UIA: OXYGEN O₂ VENT — CLOSE.
+4. DCU (both crew): OXY — PRI.
+5. UIA: OXYGEN EMU-1 — OPEN.
+6. HMD: Wait until EV1 Primary O₂ tank is &gt; 3000 psi.
+7. UIA: OXYGEN EMU-1 — CLOSE.
+8. DCU (both crew): OXY — SEC.
+9. UIA: OXYGEN EMU-1 — OPEN.
+10. HMD: Wait until EV1 Secondary O₂ tank is &gt; 3000 psi.
+11. UIA: OXYGEN EMU-1 — CLOSE.
+12. DCU (both crew): OXY — PRI.
+
+### End Depress, Check Switches, Disconnect
+1. HMD: Wait until Suit Pressure and O₂ Pressure equal 4.
+2. UIA: DEPRESS PUMP PWR — OFF.
+3. DCU (both crew): BATT — LOCAL.
+4. UIA: EV-1 EMU PWR — OFF.
+5. DCU (both crew): Verify OXY — PRI.
+6. DCU (both crew): Verify COMMS — A.
+7. DCU (both crew): Verify FAN — PRI.
+8. DCU (both crew): Verify PUMP — CLOSE.
+9. DCU (both crew): Verify CO₂ — A.
+10. EV1 disconnects UIA and DCU umbilicals.

--- a/docs/fy26-suits-proposal-guidelines.md
+++ b/docs/fy26-suits-proposal-guidelines.md
@@ -1,0 +1,262 @@
+# NASA SUITS FY26 — Proposal Guidelines (2025–2026)
+
+National Aeronautics and Space Administration (NASA) — Spacesuit User Interface Technologies for Students (SUITS)
+
+Official site: [www.nasa.gov/stem](https://www.nasa.gov/stem)
+
+## Cover Page Template
+Provide the following information on the proposal cover page:
+
+- Team Name
+- Optional Team Logo
+- Academic Institution Name
+- Address
+- Team Contact (student name, email address, phone number)
+- Complete list of team members with each member’s role, email address, academic year, and academic major
+- Faculty Advisor (name, email address, phone number, signature, and date)
+
+## Table of Contents Reminder
+The proposal must include the following sections:
+
+1. Introduction
+2. Eligibility
+3. Letter of Intent
+4. Proposal Requirements
+5. Technical Section
+   - Abstract
+   - Software and Hardware Design Description
+   - Concept of Operations (CONOPS)
+   - Artificial Intelligence
+   - Human-in-the-loop (HITL) Testing
+   - Project Management
+   - Technical References
+6. Community and Industry Engagement Section
+   - Community Engagement
+   - Industry Engagement
+7. Administrative Section
+   - Institutional Letter of Endorsement
+   - Statement of Supervising Faculty
+   - Statement of Rights of Use
+   - Funding and Budget Statement
+   - Hololens2 Loan Program
+   - Proposal Scoring Method
+   - Other Deliverables
+   - Logo Use
+8. Proposal Scoring Rubric
+
+> **Note:** The Technical Section is limited to 12 pages. Include sufficient imagery within those pages to describe your software. Additional images belong in an appendix. Other sections and appendices do not count against the 12-page limit.
+
+## 1. Introduction
+The Extravehicular Activity and Human Surface Mobility Program (EHP) and the Office of STEM Engagement at NASA Johnson Space Center (Houston) host the ninth annual NASA SUITS Challenge. Onsite device testing occurs at Johnson in May 2026. This guide outlines the requirements for submitting a successful proposal and summarizes required steps in the challenge. Refer to the Mission Description at <https://go.nasa.gov/nasasuits> for scenario details.
+
+## 2. Eligibility
+Each onsite team member must be enrolled as an undergraduate or graduate student at an accredited U.S. institution (community college, military academy, technical college, or university). Enrollment verification may be requested at any time.
+
+- Team members must be at least 18 before arriving in Houston.
+- Institutions are encouraged to submit multiple proposals when many students are interested. There is currently no plan to offer an offsite option for non-badged participants in 2026.
+- Each team must be accompanied onsite by its faculty advisor or an adult (age 21 or older) serving as the advisor.
+- All participants must attend the Orientation on **December 11, 2025 at 4:00 p.m. CST** and the virtual Software Design Review on **April 2, 2026**.
+- Team members may participate with only one team per competition cycle.
+- Student experiments must be organized, designed, and operated solely by student team members.
+- All participants must enroll for the activity in STEM Gateway and accept their offer by NASA’s stated deadline.
+- Interns who helped design a SUITS challenge may not participate as team members in the same cycle but may serve as advisors.
+
+## 3. Letter of Intent (LOI)
+Submit an LOI by **Thursday, October 2, 2025** indicating intent to submit a full proposal. Email the LOI directly to [nasa-suits@mail.nasa.gov](mailto:nasa-suits@mail.nasa.gov). Teams may still submit a proposal without an LOI.
+
+- **Subject line:** “NASA SUITS Challenge Letter of Intent.”
+- **Body sample:** “We are Team &lt;name&gt; from &lt;Institution Name&gt;. We intend to submit a proposal for the 2026 NASA SUITS Challenge.”
+- Provide student team contact information (name, email, academic year, major).
+- List all academic institutions represented. Designate a lead institution when multiple schools collaborate.
+
+## 4. Proposal Requirements
+- Submit one electronic copy of the original proposal via NASA STEM Gateway by **Thursday, October 30, 2025**.
+- The proposal must contain three sections: Technical, Outreach, and Administrative.
+- Do **not** skip or omit required sections or components.
+- Limit the Technical Section to **12 pages**.
+- Use 12-point font for the report body.
+- Complete every field on the title page.
+- Label and reference every figure and table in the text.
+
+## 5. Technical Section Requirements
+Technical reviewers evaluate only this section when scoring scientific and technical merit. Address every component below:
+
+### a. Abstract
+Provide a summary (up to 500 words) covering the proposed prototype design, how it meets Mission Description requirements, planned testing, and any proposed hardware or peripheral devices for onsite use.
+
+### b. Software and Hardware Design Description
+Detail the proposed software, system architecture, hardware concepts, network diagrams, and AI integration strategy. Explain how the UI and voice assistant address each aspect of the EVA scenario. Include conceptual UI designs (wireframes, visuals) for navigation, telemetry, rover controls, geology, EVA task instructions, etc., along with peripheral mock-ups.
+
+### c. Concept of Operations (CONOPS)
+Describe how the design meets expectations and requirements from an operational (astronaut) perspective. Explain how the application aids the evaluator/astronaut during each EVA phase. Flowcharts showing mission-wide interactions are encouraged.
+
+### d. Artificial Intelligence
+Explain how AI acts as a force multiplier to increase efficiency or reduce cognitive load. Identify the AI models (LLMs or otherwise), justify their selection, and describe safeguards against hallucinations in mission-critical contexts.
+
+### e. Human-in-the-Loop (HITL) Testing
+Describe planned pilot, UX, HITL, or human factors studies. Provide a schedule with proposed dates/times, test protocols, metrics, subject pools/demographics, and safety measures. Explain how HITL results inform development, including night/low-light, outdoor, and network/telemetry testing. A strong HITL plan culminates in a full rehearsal of the EVA scenario before Test Week. Do not duplicate this section for both assets.
+
+### f. Project Management
+Outline development plans, internal milestones, and schedules (e.g., Gantt chart or Agile sprint plan). Describe how progress tracking ensures compliance with mission requirements ahead of Test Week. Plan recurring testing under EVA-like conditions. Expect NASA to hold teams accountable for provided milestones.
+
+### g. Technical References
+Cite all referenced works in-text and list them in a “References” section using a recognized technical format.
+
+## 6. Community and Industry Engagement
+### a. Community Engagement
+Create an engagement plan describing objectives, activities, locations, timing, target audiences, and materials. Include:
+
+- Outreach audiences (e.g., K–12 classes, undergraduate research events, university-to-school programs, Scouts, after-school clubs, church groups).
+- Letters or agreements from organizations that accept invitations.
+- Objectives for each activity.
+- Detailed activity plans aligned with relevant standards or age-appropriate language.
+- A press and/or social media plan.
+- Connections between activities and NASA SUITS, another NASA mission, or the team’s software.
+
+> Leading an “Hour of Code” classroom activity is highlighted as an optimal outreach event.
+
+### b. Industry Engagement
+List potential industry partners aligned with project goals. Address at least one professional development element such as:
+
+- Mentorship arrangements with industry experts/partners.
+- Skills development or certification opportunities (software, electrical, etc.).
+- Support of team members’ career goals through industry connections.
+- Potential internship, fellowship, apprenticeship, or career opportunities pursued by team members.
+- Methods for raising awareness about participation in the NASA SUITS challenge.
+
+## 7. Administrative Section
+### a. Institutional Letter of Endorsement
+Provide an institutional letter (president, dean, or department chair) on official letterhead affirming awareness of and support for team participation. Missing letters result in rejection.
+
+### b. Statement of Supervising Faculty
+Submit a letter on institutional letterhead signed by the faculty advisor confirming willingness to supervise the team throughout the activity and acknowledging responsibility for meeting requirements and deadlines. Include the following statement:
+
+> As the faculty advisor for an experiment entitled "__________________" proposed by a team of higher education students from __________ institution, I concur with the concepts and methods by which the students plan to conduct this project. I will ensure the student team members complete all project requirements and meet deadlines in a timely manner. I understand any default by this team concerning any project requirements (including submission of final report materials) could adversely affect selection opportunities of future teams from their institution.
+
+For multi-institution teams, include the statement from the lead institution and letters of support from faculty at each participating institution acknowledging their students’ involvement.
+
+### c. Statement of Rights of Use
+These optional statements grant NASA, on behalf of the U.S. Government, rights to use the team’s technical data (software, designs, etc.) for government purposes. Teams submitting the statement receive greater consideration. All team members and faculty advisors must sign. Provide the following language:
+
+> As a team member for a proposal entitled “__________” proposed by a team of higher education students from ________ institution, I will and hereby do grant the U.S. Government a royalty-free, nonexclusive and irrevocable license to use, reproduce, distribute (including distribution by transmission) to the public, perform publicly, prepare derivative works, and display publicly, any technical data contained in this proposal in whole or in part and in any manner for federal purposes and to have or permit others to do so for federal purposes only. Further, with respect to all computer software designated by NASA to be released as open source which is first produced or delivered under this proposal and subsequent collaboration, if selected, shall be delivered with unlimited and unrestricted rights so as to permit further distribution as open source. For purposes of defining the rights in such computer software, “computer software” shall include source codes, object codes, executables, ancillary files, and any and all documentation related to any computer program or similar set of instructions delivered in association with this collaboration.
+>
+> As a team member for a proposal entitled “__________” proposed by a team of higher education students from ________ institution(s), I will and hereby do grant the U.S. Government a nonexclusive, nontransferable, irrevocable, paid-up license to practice or have practiced for or on behalf of the United States Government any invention described or made part of this proposal throughout the world.
+
+### d. Funding and Budget Statement
+Provide a simple table of expected expenditures (materials, machining, operating, testing, shipping, travel, lodging, food, etc.) and list potential funding sources (institutional grants, Space Grant funds, corporate sponsors). Teams are responsible for all costs. NASA SUITS will notify participants if funding or allowances become available.
+
+**Example Budget**
+
+| Items                | Costs |
+|----------------------|------:|
+| Flights              | $4,500 |
+| Hotel                | $2,000 |
+| Ground transportation| $400 |
+| Operating            | $600 |
+| Software             | $500 |
+| Miscellaneous        | $500 |
+| **Total**            | **$8,500** |
+
+### e. Hololens2 Loan Program
+NASA SUITS has a limited number of Hololens2 devices available via institutional loan agreements. Indicate one of the following options:
+
+A) We do not require a loaned device because we already have or will acquire one.
+
+B) We need a loaned device from NASA SUITS to participate.
+
+C) We have a device but would still like to be considered for a loan to aid development.
+
+### f. Proposal Scoring Method
+Proposals are evaluated using the scoring rubrics in Section 8, covering Technical Merit, Engagement Plans, and compliance with requirements.
+
+### g. Other Deliverables
+Teams must produce a first-person point-of-view video demonstrating their UI in action and submit the video with code during the Software Design Reviews in April 2025. Teams must also submit a draft white paper documenting visual informatics display development upon completing the NASA SUITS challenge in June 2025.
+
+### h. Logo Use
+Upload institution logo files (JPG or PNG) to STEM Gateway. Provide both horizontal and stacked (vertical) versions, or share a public-facing link.
+
+## 8. Proposal Scoring Rubric
+### 8.1 Technical Merit (Total Technical Score)
+
+#### Design Description (20–25 points)
+- Describe design goals and expected results.
+- Provide a roadmap for integrating AI for autonomous functions.
+- Address UI components for both spacesuit and PR challenges.
+
+Scoring guidance:
+- **0–10 points:** Concept is unclear or fails to address challenge components.
+- **11–19 points:** Some components addressed, limited evidence of innovation.
+- **20–25 points:** Goals and results are clearly described with substantial evidence of innovative interactions; most or all challenge components addressed successfully.
+
+#### Concept of Operations (Total 10 points)
+- Describe UI, autonomy, and interoperability from an operational perspective (PR and spacesuit).
+
+Scoring guidance:
+- **0–2 points:** Unclear or insufficient operational description.
+- **3–5 points:** Few details; difficult to comprehend operationally.
+- **6–8 points:** Provides general details and a basic operational understanding.
+- **9–10 points:** Clear, concise, detailed operational explanation.
+
+#### Feasibility (Total 10 points)
+- Demonstrate a viable solution to the technical need.
+- Describe how the concept will be produced.
+
+Scoring guidance:
+- **0–1 points:** Lacks viability; no production evidence.
+- **2–4 points:** Low viability; minimal production details.
+- **5–7 points:** Sufficient viability; limited production evidence.
+- **8–10 points:** High viability; detailed production plan.
+
+#### Artificial Intelligence Integration (Total 15 points)
+- Explain how and where AI will be included.
+- Specify which LLMs or other AI models will be used and why.
+- Detail strategies to mitigate hallucinations that could threaten mission success.
+
+Scoring guidance:
+- **0–3 points:** Fails to explain AI integration, model choice, or mitigation.
+- **4–7 points:** Basic explanation with limited justification or safeguards.
+- **8–11 points:** Practical plan with reasonable model justification and mitigation.
+- **12–15 points:** Comprehensive, innovative integration with well-justified models and robust mitigation strategies.
+
+#### Effectiveness of the Proposed Project Schedule (Total 5 points)
+- Provide a comprehensive schedule that uses available resources effectively, distributes labor, documents the plan to meet objectives, and details how each objective/task will be achieved.
+
+Scoring guidance:
+- **0 points:** No effective planning or task/objective description.
+- **1–2 points:** Few details; vague path to objectives.
+- **3–4 points:** Minimal detail; basic approach to meeting objectives.
+- **5 points:** Highly detailed, effective schedule demonstrating how objectives will be achieved.
+
+#### Human-in-the-Loop (HITL) Testing (Total 10 points)
+- Provide a HITL test plan covering the schedule, protocols, metrics/measures, feasible subject pools/demographics, and how each event evaluates progress toward meeting challenge requirements. All testing must be safe.
+
+Scoring guidance:
+- **1–2 points:** No plan or insufficient/unsafe/unclear components.
+- **3–5 points:** Few required components included.
+- **6–7 points:** Most components included but not all.
+- **8–10 points:** Clear, concise plan containing all requested components.
+
+#### Technical References (Total 5 points)
+- Cite relevant works in text and provide a properly formatted bibliography.
+
+Scoring guidance:
+- **0 points:** No references.
+- **1–2 points:** One reference cited but not formatted correctly.
+- **3–4 points:** At least one correctly formatted reference.
+- **5 points:** Two or more references cited with recognized formatting.
+
+### 8.2 Engagement Plan Scoring (Total 20 points)
+
+#### Community Engagements and Industry Engagements
+- Present a diverse list of outreach events and industry engagements, projected audience types and participant numbers, community leaders engaged, and detailed implementation plans.
+- Demonstrate alignment between industry partners and project goals, including professional development strategies.
+
+Scoring guidance:
+- **1–5 points:** Only one total engagement or no implementation/partner detail.
+- **6–10 points:** At least two engagements with minimal implementation or partner detail.
+- **11–15 points:** At least three engagements with sufficiently detailed implementation plans and/or detailed partner alignment.
+- **16–20 points:** At least four engagements with highly descriptive, relevant implementation plans and partner alignment.
+
+## 9. Final Reminders
+- Check the NASA SUITS website (<http://go.nasa.gov/nasasuits>) for the most up-to-date activity documents.
+- Direct questions and responses to [nasa-suits@mail.nasa.gov](mailto:nasa-suits@mail.nasa.gov).


### PR DESCRIPTION
## Summary
- add a NASA SUITS FY26 FAQ markdown file that mirrors the answers from the FY26 PDF reference
- transcribe the FY26 mission description PDF into markdown, including scenario threads, requirements, and sample procedures
- convert the FY26 proposal guidelines PDF into markdown with cover requirements, submission rules, and scoring rubrics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eebbd87414832fbfcda5c1db6da95a